### PR TITLE
Match cleanup

### DIFF
--- a/src/lib/include/ast/match.h
+++ b/src/lib/include/ast/match.h
@@ -29,35 +29,35 @@ private:
 
 class Either : public MatchExpression {
 public:
-  Either(MatchExpression *l, MatchExpression *r) :
+  Either(const MatchExpression &l, const MatchExpression &r) :
     left_(l), right_(r) {}
 
   virtual bool match(const Expression &e) const override;
 private:
-  const MatchExpression *left_;
-  const MatchExpression *right_;
+  const MatchExpression &left_;
+  const MatchExpression &right_;
 };
 
 class Both : public MatchExpression {
 public:
-  Both(MatchExpression *l, MatchExpression *r) :
+  Both(const MatchExpression &l, const MatchExpression &r) :
     left_(l), right_(r) {}
 
   virtual bool match(const Expression &e) const override;
 private:
-  const MatchExpression *left_;
-  const MatchExpression *right_;
+  const MatchExpression &left_;
+  const MatchExpression &right_;
 };
 
 class HasChild : public MatchExpression {
 public:
-  HasChild(MatchExpression *e) :
+  HasChild(const MatchExpression &e) :
     expr_(e) {}
 
   virtual bool match(const Expression &e) const override;
 
 private:
-  const MatchExpression *expr_;
+  const MatchExpression &expr_;
 };
 
 }

--- a/src/lib/include/ast/match.h
+++ b/src/lib/include/ast/match.h
@@ -7,14 +7,14 @@ namespace ast {
 
 class MatchExpression {
 public:
-  virtual bool match(Expression *e) const = 0;
+  virtual bool match(const Expression &e) const = 0;
 };
 
 class Any : public MatchExpression {
 public:
   Any() {}
 
-  virtual bool match(Expression *e) const override;
+  virtual bool match(const Expression &e) const override;
 };
 
 class Exact : public MatchExpression {
@@ -22,7 +22,7 @@ public:
   Exact(const Symbol& sym) :
     symbol_(sym) {}
 
-  virtual bool match(Expression *e) const override;
+  virtual bool match(const Expression &e) const override;
 private:
   const Symbol& symbol_;
 };
@@ -32,7 +32,7 @@ public:
   Either(MatchExpression *l, MatchExpression *r) :
     left_(l), right_(r) {}
 
-  virtual bool match(Expression *e) const override;
+  virtual bool match(const Expression &e) const override;
 private:
   const MatchExpression *left_;
   const MatchExpression *right_;
@@ -43,7 +43,7 @@ public:
   Both(MatchExpression *l, MatchExpression *r) :
     left_(l), right_(r) {}
 
-  virtual bool match(Expression *e) const override;
+  virtual bool match(const Expression &e) const override;
 private:
   const MatchExpression *left_;
   const MatchExpression *right_;
@@ -54,7 +54,7 @@ public:
   HasChild(MatchExpression *e) :
     expr_(e) {}
 
-  virtual bool match(Expression *e) const override;
+  virtual bool match(const Expression &e) const override;
 
 private:
   const MatchExpression *expr_;

--- a/src/lib/src/match.cpp
+++ b/src/lib/src/match.cpp
@@ -2,35 +2,35 @@
 
 namespace ast {
 
-bool Any::match(Expression *e) const
+bool Any::match(const Expression &e) const
 {
   return true;
 }
 
-bool Exact::match(Expression *e) const
+bool Exact::match(const Expression &e) const
 {
-  if(auto sym = dynamic_cast<Symbol *>(e)) {
+  if(auto sym = dynamic_cast<const Symbol *>(&e)) {
     return *sym == symbol_;
   }
 
   return false;
 }
 
-bool Either::match(Expression *e) const
+bool Either::match(const Expression &e) const
 {
   return left_->match(e) || right_->match(e);
 }
 
-bool Both::match(Expression *e) const
+bool Both::match(const Expression &e) const
 {
   return left_->match(e) && right_->match(e);
 }
 
-bool HasChild::match(Expression *e) const
+bool HasChild::match(const Expression &e) const
 {
-  if(auto comp = dynamic_cast<Composite *>(e)) {
+  if(auto comp = dynamic_cast<const Composite *>(&e)) {
     return std::any_of(std::cbegin(*comp), std::cend(*comp), [&](auto&& ch) {
-      return expr_->match(ch.get());
+      return expr_->match(*ch);
     });
   }
 

--- a/src/lib/src/match.cpp
+++ b/src/lib/src/match.cpp
@@ -18,19 +18,19 @@ bool Exact::match(const Expression &e) const
 
 bool Either::match(const Expression &e) const
 {
-  return left_->match(e) || right_->match(e);
+  return left_.match(e) || right_.match(e);
 }
 
 bool Both::match(const Expression &e) const
 {
-  return left_->match(e) && right_->match(e);
+  return left_.match(e) && right_.match(e);
 }
 
 bool HasChild::match(const Expression &e) const
 {
   if(auto comp = dynamic_cast<const Composite *>(&e)) {
     return std::any_of(std::cbegin(*comp), std::cend(*comp), [&](auto&& ch) {
-      return expr_->match(*ch);
+      return expr_.match(*ch);
     });
   }
 

--- a/src/lib/test/match.cpp
+++ b/src/lib/test/match.cpp
@@ -2,78 +2,66 @@
 
 #include "catch.h"
 
+using namespace ast;
+
 TEST_CASE("any matches") {
-  auto a = ast::Any();
+  auto a = Any();
 
-  auto s = std::make_unique<ast::Symbol>("dj");
-  REQUIRE(a.match(ast::Symbol("dj")));
-
-  auto c = std::make_unique<ast::Composite>();
-  REQUIRE(a.match(*c));
+  REQUIRE(a.match(Symbol("dj")));
+  REQUIRE(a.match(Composite()));
 }
 
 TEST_CASE("exact matches") {
-  auto ex = ast::Exact(ast::Symbol("sym"));
+  auto ex = Exact(Symbol("sym"));
 
-  auto s = std::make_unique<ast::Symbol>("sym");
-  REQUIRE(ex.match(*s));
+  REQUIRE(ex.match(Symbol("sym")));
+  REQUIRE(!ex.match(Symbol("jefw")));
 
-  auto t = std::make_unique<ast::Symbol>("jefw");
-  REQUIRE(!ex.match(*t));
-
-  auto c = ast::Composite();
-  c.add_member(ast::Symbol("sym"));
+  auto c = Composite();
+  c.add_member(Symbol("sym"));
   REQUIRE(!ex.match(c));
 }
 
 TEST_CASE("either matches") {
-  auto a = std::make_unique<ast::Exact>(ast::Symbol("a"));
-  auto b = std::make_unique<ast::Exact>(ast::Symbol("b"));
-  auto e = ast::Either(a.get(), b.get());
+  auto a = std::make_unique<Exact>(Symbol("a"));
+  auto b = std::make_unique<Exact>(Symbol("b"));
+  auto e = Either(a.get(), b.get());
 
-  auto s = std::make_unique<ast::Symbol>("a");
-  REQUIRE(e.match(*s));
-
-  auto t = std::make_unique<ast::Symbol>("b");
-  REQUIRE(e.match(*t));
-
-  auto u = std::make_unique<ast::Symbol>("c");
-  REQUIRE(!e.match(*u));
+  REQUIRE(e.match(Symbol("a")));
+  REQUIRE(e.match(Symbol("b")));
+  REQUIRE(!e.match(Symbol("c")));
 }
 
 TEST_CASE("both matches") {
-  auto a = ast::Exact(ast::Symbol("a"));
-  auto ca = ast::HasChild(&a);
+  auto a = Exact(Symbol("a"));
+  auto ca = HasChild(&a);
 
-  auto b = ast::Exact(ast::Symbol("b"));
-  auto cb = ast::HasChild(&b);
+  auto b = Exact(Symbol("b"));
+  auto cb = HasChild(&b);
 
-  auto c = ast::Both(&ca, &cb);
+  auto c = Both(&ca, &cb);
 
-  auto comp = ast::Composite();
-  comp.add_member(ast::Symbol("a"));
+  auto comp = Composite();
+  comp.add_member(Symbol("a"));
   REQUIRE(!c.match(comp));
 
-  comp.add_member(ast::Symbol("b"));
+  comp.add_member(Symbol("b"));
   REQUIRE(c.match(comp));
 }
 
 TEST_CASE("has child matches") {
-  auto ch = ast::Exact(ast::Symbol("sym"));
-  auto ex = ast::HasChild(&ch);
+  auto ch = Exact(Symbol("sym"));
+  auto ex = HasChild(&ch);
 
-  auto c = ast::Composite();
-  c.add_member(ast::Symbol("sym"));
+  auto c = Composite();
+  c.add_member(Symbol("sym"));
   REQUIRE(ex.match(c));
 
-  auto d = ast::Composite();
-  REQUIRE(!ex.match(d));
-  
-  auto e = ast::Symbol("sym");
-  REQUIRE(!ex.match(e));
+  REQUIRE(!ex.match(Composite()));
+  REQUIRE(!ex.match(Symbol("sym")));
 
-  auto f = ast::Composite();
-  f.add_member(ast::Symbol("ewoi"));
-  f.add_member(ast::Symbol("sym"));
+  auto f = Composite();
+  f.add_member(Symbol("ewoi"));
+  f.add_member(Symbol("sym"));
   REQUIRE(ex.match(f));
 }

--- a/src/lib/test/match.cpp
+++ b/src/lib/test/match.cpp
@@ -6,24 +6,24 @@ TEST_CASE("any matches") {
   auto a = ast::Any();
 
   auto s = std::make_unique<ast::Symbol>("dj");
-  REQUIRE(a.match(s.get()));
+  REQUIRE(a.match(ast::Symbol("dj")));
 
   auto c = std::make_unique<ast::Composite>();
-  REQUIRE(a.match(c.get()));
+  REQUIRE(a.match(*c));
 }
 
 TEST_CASE("exact matches") {
   auto ex = ast::Exact(ast::Symbol("sym"));
 
   auto s = std::make_unique<ast::Symbol>("sym");
-  REQUIRE(ex.match(s.get()));
+  REQUIRE(ex.match(*s));
 
   auto t = std::make_unique<ast::Symbol>("jefw");
-  REQUIRE(!ex.match(t.get()));
+  REQUIRE(!ex.match(*t));
 
   auto c = ast::Composite();
   c.add_member(ast::Symbol("sym"));
-  REQUIRE(!ex.match(&c));
+  REQUIRE(!ex.match(c));
 }
 
 TEST_CASE("either matches") {
@@ -32,13 +32,13 @@ TEST_CASE("either matches") {
   auto e = ast::Either(a.get(), b.get());
 
   auto s = std::make_unique<ast::Symbol>("a");
-  REQUIRE(e.match(s.get()));
+  REQUIRE(e.match(*s));
 
   auto t = std::make_unique<ast::Symbol>("b");
-  REQUIRE(e.match(t.get()));
+  REQUIRE(e.match(*t));
 
   auto u = std::make_unique<ast::Symbol>("c");
-  REQUIRE(!e.match(u.get()));
+  REQUIRE(!e.match(*u));
 }
 
 TEST_CASE("both matches") {
@@ -52,10 +52,10 @@ TEST_CASE("both matches") {
 
   auto comp = ast::Composite();
   comp.add_member(ast::Symbol("a"));
-  REQUIRE(!c.match(&comp));
+  REQUIRE(!c.match(comp));
 
   comp.add_member(ast::Symbol("b"));
-  REQUIRE(c.match(&comp));
+  REQUIRE(c.match(comp));
 }
 
 TEST_CASE("has child matches") {
@@ -64,16 +64,16 @@ TEST_CASE("has child matches") {
 
   auto c = ast::Composite();
   c.add_member(ast::Symbol("sym"));
-  REQUIRE(ex.match(&c));
+  REQUIRE(ex.match(c));
 
   auto d = ast::Composite();
-  REQUIRE(!ex.match(&d));
+  REQUIRE(!ex.match(d));
   
   auto e = ast::Symbol("sym");
-  REQUIRE(!ex.match(&e));
+  REQUIRE(!ex.match(e));
 
   auto f = ast::Composite();
   f.add_member(ast::Symbol("ewoi"));
   f.add_member(ast::Symbol("sym"));
-  REQUIRE(ex.match(&f));
+  REQUIRE(ex.match(f));
 }

--- a/src/lib/test/match.cpp
+++ b/src/lib/test/match.cpp
@@ -23,9 +23,7 @@ TEST_CASE("exact matches") {
 }
 
 TEST_CASE("either matches") {
-  auto a = std::make_unique<Exact>(Symbol("a"));
-  auto b = std::make_unique<Exact>(Symbol("b"));
-  auto e = Either(a.get(), b.get());
+  auto e = Either(Exact(Symbol("a")), Exact(Symbol("b")));
 
   REQUIRE(e.match(Symbol("a")));
   REQUIRE(e.match(Symbol("b")));
@@ -34,12 +32,8 @@ TEST_CASE("either matches") {
 
 TEST_CASE("both matches") {
   auto a = Exact(Symbol("a"));
-  auto ca = HasChild(&a);
-
   auto b = Exact(Symbol("b"));
-  auto cb = HasChild(&b);
-
-  auto c = Both(&ca, &cb);
+  auto c = Both(HasChild(a), HasChild(b));
 
   auto comp = Composite();
   comp.add_member(Symbol("a"));
@@ -51,7 +45,7 @@ TEST_CASE("both matches") {
 
 TEST_CASE("has child matches") {
   auto ch = Exact(Symbol("sym"));
-  auto ex = HasChild(&ch);
+  auto ex = HasChild(ch);
 
   auto c = Composite();
   c.add_member(Symbol("sym"));


### PR DESCRIPTION
This cleans up the matching / construction API by using references instead of pointers.