### PR TITLE
Improve ownership etc

### DIFF
--- a/src/lib/src/match.cpp
+++ b/src/lib/src/match.cpp
@@ -28,19 +28,19 @@ bool Exact::match(const Expression &e) const
 
 bool Either::match(const Expression &e) const
 {
-  return left_.match(e) || right_.match(e);
+  return left_->match(e) || right_->match(e);
 }
 
 bool Both::match(const Expression &e) const
 {
-  return left_.match(e) && right_.match(e);
+  return left_->match(e) && right_->match(e);
 }
 
 bool HasChild::match(const Expression &e) const
 {
   if(auto comp = dynamic_cast<const Composite *>(&e)) {
     return std::any_of(std::cbegin(*comp), std::cend(*comp), [&](auto&& ch) {
-      return expr_.match(*ch);
+      return expr_->match(*ch);
     });
   }
 
@@ -63,7 +63,7 @@ bool Child::match(const Expression &e) const
       return false;
     }
 
-    return expr_.match(*((*comp)[num_]));
+    return expr_->match(*((*comp)[num_]));
   }
 
   return false;


### PR DESCRIPTION
This means that the AST matching structures don't try to hold on to references past their lifetime - they allocate a cloned instance and hold it in a `unique_ptr` instead.