### PR TITLE
Implement variadic construction for composites

### DIFF
--- a/src/lib/include/ast/ast.h
+++ b/src/lib/include/ast/ast.h
@@ -30,14 +30,14 @@ public:
 
 class Composite : public Expression {
 public:
-  template<class Iterator>
-  Composite(Iterator begin, Iterator end);
-
   Composite() {};
+
+  template<class T, class... Ts>
+  explicit Composite(T&& t, Ts&&... rest);
 
   Composite(const Composite& other) {
     for(auto&& e : other) {
-      members_.push_back(std::unique_ptr<Expression>(e->clone()));
+      members_.emplace_back(e->clone());
     }
   }
 
@@ -46,8 +46,7 @@ public:
     return *this;
   }
 
-  template<class Expr>
-  void add_member(Expr&& e);
+  void add_member(const Expression& e);
 
   void add_member(std::unique_ptr<Expression> e);
 
@@ -75,18 +74,11 @@ bool operator< (const Symbol& rhs, const Symbol& lhs);
 bool operator== (const Composite& rhs, const Composite& lhs);
 bool operator!= (const Composite& rhs, const Composite& lhs);
 
-template<class Iterator>
-Composite::Composite(Iterator begin, Iterator end)
+template<class T, class... Ts>
+Composite::Composite(T&& t, Ts&&... rest) :
+  Composite(rest...)
 {
-  for(auto it = begin; it != end; ++it) {
-    members_.push_back(std::move(*it));
-  }
-}
-
-template<class Expr>
-void Composite::add_member(Expr&& e)
-{
-  members_.emplace_back(new typename std::remove_reference<Expr>::type (std::move(e)));
+  members_.emplace(std::begin(members_), t.clone());
 }
 
 }

--- a/src/lib/include/ast/parser.h
+++ b/src/lib/include/ast/parser.h
@@ -8,19 +8,18 @@
 
 namespace ast {
 
-template<class T>
 class ParseResult {
 public:
   ParseResult() :
     data(nullptr) {}
 
-  ParseResult(T t, std::string::const_iterator end) :
-    data(new T(t)), end_(end) {}
+  ParseResult(const Expression& t, std::string::const_iterator end) :
+    data(t.clone()), end_(end) {}
 
-  ParseResult(const ParseResult<T>& other) :
-    data(new T(*other.data)), end_(other.end_) {}
+  ParseResult(const ParseResult& other) :
+    data(other.data->clone()), end_(other.end_) {}
 
-  ParseResult<T>& operator=(ParseResult<T> other) {
+  ParseResult operator=(ParseResult other) {
     std::swap(data, other.data);
     std::swap(end_, other.end_);
     return *this;
@@ -31,7 +30,7 @@ public:
     return end_; 
   }
 
-  std::unique_ptr<T> data;
+  std::unique_ptr<Expression> data;
 
   operator bool() const {
     return static_cast<bool>(data);
@@ -49,10 +48,10 @@ public:
   SymbolParser(const std::string& s) :
     SymbolParser(std::begin(s), std::end(s)) {}
 
-  ParseResult<Symbol> get() const;
+  ParseResult get() const;
 private:
-  ParseResult<Symbol> get_unquoted() const;
-  ParseResult<Symbol> get_quoted() const;
+  ParseResult get_unquoted() const;
+  ParseResult get_quoted() const;
 
   const std::string::const_iterator begin_;
   const std::string::const_iterator end_;
@@ -67,7 +66,7 @@ public:
   CompositeParser(const std::string& s) :
     CompositeParser(std::begin(s), std::end(s)) {}
 
-  ParseResult<Composite> get() const;
+  ParseResult get() const;
 private:
   using iterator = std::string::const_iterator;
 

--- a/src/lib/src/ast.cpp
+++ b/src/lib/src/ast.cpp
@@ -26,6 +26,11 @@ void Composite::add_member(std::unique_ptr<Expression> e)
   members_.push_back(std::move(e));
 }
 
+void Composite::add_member(const Expression& e)
+{
+  members_.emplace_back(e.clone());
+}
+
 const std::unique_ptr<Expression>& Composite::operator[](std::size_t idx) const
 {
   return members_.at(idx);

--- a/src/lib/src/parser.cpp
+++ b/src/lib/src/parser.cpp
@@ -7,12 +7,12 @@
 
 namespace ast {
 
-ParseResult<Symbol> SymbolParser::get() const
+ParseResult SymbolParser::get() const
 {
   auto it = begin_;
 
   if(*it != ':') {
-    return ParseResult<Symbol>{};
+    return ParseResult{};
   }
   it++;
 
@@ -23,10 +23,10 @@ ParseResult<Symbol> SymbolParser::get() const
   }
 }
 
-ParseResult<Symbol> SymbolParser::get_unquoted() const
+ParseResult SymbolParser::get_unquoted() const
 {
   if(end_ - begin_ <= 1) {
-    return ParseResult<Symbol>{};
+    return ParseResult{};
   }
 
   std::stringstream ss;
@@ -41,20 +41,20 @@ ParseResult<Symbol> SymbolParser::get_unquoted() const
   }
 
   if(ss.str().empty()) {
-    return ParseResult<Symbol>{};
+    return ParseResult{};
   }
 
-  return ParseResult<Symbol>(Symbol(ss.str()), it);
+  return ParseResult(Symbol(ss.str()), it);
 }
 
-ParseResult<Symbol> SymbolParser::get_quoted() const
+ParseResult SymbolParser::get_quoted() const
 {
   if(end_ - begin_ <= 2) {
-    return ParseResult<Symbol>{};
+    return ParseResult{};
   }
 
   if(*begin_ != ':' || *(begin_ + 1) != '"') {
-    return ParseResult<Symbol>{};
+    return ParseResult{};
   }
 
   std::stringstream ss;
@@ -69,15 +69,15 @@ ParseResult<Symbol> SymbolParser::get_quoted() const
     ss << *it;
   }
 
-  return ParseResult<Symbol>(Symbol(ss.str()), it);
+  return ParseResult(Symbol(ss.str()), it);
 }
 
-ParseResult<Composite> CompositeParser::get() const
+ParseResult CompositeParser::get() const
 {
   auto it = skip_whitespace(begin_);
 
   if(*it != '(') {
-    return ParseResult<Composite>{};
+    return ParseResult{};
   }
   it++;
 
@@ -104,10 +104,10 @@ ParseResult<Composite> CompositeParser::get() const
 
   it = skip_whitespace(it);
   if(*it != ')') {
-    return ParseResult<Composite>{};
+    return ParseResult{};
   }
 
-  return ParseResult<Composite>(c, it+1);
+  return ParseResult(c, it+1);
 }
 
 }

--- a/src/lib/test/ast.cpp
+++ b/src/lib/test/ast.cpp
@@ -52,20 +52,23 @@ TEST_CASE("composites can be constructed") {
     REQUIRE(c.size() == 0);
   }
 
-  SECTION("they can be constructed from iterators") {
-    std::vector<std::unique_ptr<ast::Expression>> v{};
-    v.emplace_back(new ast::Symbol("a"));
-    v.emplace_back(new ast::Symbol("b"));
-    v.emplace_back(new ast::Composite);
+  SECTION("they can be constructed variadically") {
+    ast::Composite c{
+      ast::Symbol("a"),
+      ast::Symbol("b"),
+      ast::Composite{
+        ast::Symbol("c")
+      }
+    };
 
-    ast::Composite c(std::begin(v), std::end(v));
     REQUIRE(c.size() == 3);
+    REQUIRE(static_cast<ast::Composite *>(c[2].get())->size() == 1);
   }
 
   SECTION("they can have new members added") {
     ast::Composite c;
     c.add_member(ast::Symbol("a"));
-    c.add_member(ast::Composite{});
+    c.add_member(ast::Composite());
     REQUIRE(c.size() == 2);
   }
 }

--- a/src/lib/test/parser.cpp
+++ b/src/lib/test/parser.cpp
@@ -2,15 +2,17 @@
 
 #include "catch.h"
 
+using namespace ast;
+
 TEST_CASE("symbols can be parsed") {
   SECTION("unquoted symbols") {
     auto sym = ast::SymbolParser(":hello").get();
     REQUIRE(sym);
-    REQUIRE(sym.data->id == "hello");
+    REQUIRE(static_cast<Symbol *>(sym.data.get())->id == "hello");
 
     auto sym2 = ast::SymbolParser(":v").get();
     REQUIRE(sym2);
-    REQUIRE(sym2.data->id == "v");
+    REQUIRE(static_cast<Symbol *>(sym2.data.get())->id == "v");
   }
 
   SECTION("invalid unquoted symbols") {
@@ -41,23 +43,23 @@ TEST_CASE("symbols can be parsed") {
   SECTION("quoted symbols") {
     auto sym = ast::SymbolParser(":\"hello\"").get();
     REQUIRE(sym);
-    REQUIRE(sym.data->id == "hello");
+    REQUIRE(static_cast<Symbol *>(sym.data.get())->id == "hello");
 
     auto sym2 = ast::SymbolParser(":\"hi world\"").get();
     REQUIRE(sym2);
-    REQUIRE(sym2.data->id == "hi world");
+    REQUIRE(static_cast<Symbol *>(sym2.data.get())->id == "hi world");
 
     auto sym3 = ast::SymbolParser(":\":\"").get();
     REQUIRE(sym3);
-    REQUIRE(sym3.data->id == ":");
+    REQUIRE(static_cast<Symbol *>(sym3.data.get())->id == ":");
 
     auto sym4 = ast::SymbolParser(":\"\"").get();
     REQUIRE(sym4);
-    REQUIRE(sym4.data->id == "");
+    REQUIRE(static_cast<Symbol *>(sym4.data.get())->id == "");
 
     auto sym5 = ast::SymbolParser(":\"\n\"").get();
     REQUIRE(sym5);
-    REQUIRE(sym5.data->id == "\n");
+    REQUIRE(static_cast<Symbol *>(sym5.data.get())->id == "\n");
   }
 
   SECTION("invalid quoted symbols") {
@@ -79,7 +81,7 @@ TEST_CASE("symbols survive printing") {
     auto p = ast::SymbolParser(str).get();
 
     REQUIRE(p);
-    REQUIRE(s == *p.data);
+    REQUIRE(s == *static_cast<Symbol *>(p.data.get()));
   }
 }
 
@@ -87,31 +89,31 @@ TEST_CASE("composites can be parsed") {
   SECTION("empty composite") {
     auto c = ast::CompositeParser("()").get();
     REQUIRE(c);
-    REQUIRE(c.data->size() == 0);
+    REQUIRE(static_cast<Composite *>(c.data.get())->size() == 0);
   }
 
   SECTION("simple composites") {
     auto c = ast::CompositeParser("(:hello)").get();
     REQUIRE(c);
-    REQUIRE(c.data->size() == 1);
+    REQUIRE(static_cast<Composite *>(c.data.get())->size() == 1);
 
     auto c2 = ast::CompositeParser("(  :hello\t \n :lol )").get();
     REQUIRE(c2);
-    REQUIRE(c2.data->size() == 2);
+    REQUIRE(static_cast<Composite *>(c2.data.get())->size() == 2);
 
     auto c3 = ast::CompositeParser("((:hello) :lol)").get();
     REQUIRE(c3);
-    REQUIRE(c3.data->size() == 2);
+    REQUIRE(static_cast<Composite *>(c3.data.get())->size() == 2);
 
     auto c4 = ast::CompositeParser("((()))").get();
     REQUIRE(c4);
-    REQUIRE(c4.data->size() == 1);
+    REQUIRE(static_cast<Composite *>(c4.data.get())->size() == 1);
   }
 
   SECTION("leading whitespace") {
     auto c = ast::CompositeParser(" \n\t\t ()").get();
     REQUIRE(c);
-    REQUIRE(c.data->size() == 0);
+    REQUIRE(static_cast<Composite *>(c.data.get())->size() == 0);
   }
 
   SECTION("quotes, nesting") {
@@ -135,5 +137,5 @@ TEST_CASE("composites survive printing") {
   auto p = ast::CompositeParser(str).get();
   
   REQUIRE(p);
-  REQUIRE(c == *p.data);
+  REQUIRE(c == *static_cast<Composite *>(p.data.get()));
 }


### PR DESCRIPTION
This means that composites can be constructed naturally rather than having to call `add_member` repeatedly.