### PR TITLE
Implement tail matcher

### DIFF
--- a/src/lib/include/ast/match.h
+++ b/src/lib/include/ast/match.h
@@ -164,13 +164,21 @@ public:
   Child(size_t n, const MatchExpression &e) :
     num_(n), expr_(e.clone()) {}
 
-  /* Child(const Child& other) : */
-  /*   expr_(other.expr_->clone()) {} */
-
   virtual bool match(const Expression &e) const override;
   virtual Child* clone() const override { return new Child(num_, *expr_); }
 private:
   size_t num_;
+  std::unique_ptr<MatchExpression> expr_;
+};
+
+class Tail : public MatchExpression {
+public:
+  Tail(const MatchExpression &e) :
+    expr_(e.clone()) {}
+
+  virtual bool match(const Expression &e) const override;
+  virtual Tail* clone() const override { return new Tail(*expr_); }
+private:
   std::unique_ptr<MatchExpression> expr_;
 };
 

--- a/src/lib/src/match.cpp
+++ b/src/lib/src/match.cpp
@@ -105,6 +105,21 @@ bool Child::match(const Expression &e) const
   return false;
 }
 
+bool Tail::match(const Expression &e) const
+{
+  if(auto comp = dynamic_cast<const Composite *>(&e)) {
+    if(comp->size() <= 1) {
+      return false;
+    }
+
+    return std::all_of(std::begin(*comp) + 1, std::end(*comp), [&](auto&& ch) {
+      return expr_->match(*ch);
+    });
+  }
+
+  return false;
+}
+
 bool Matcher::match(const Expression &e) const
 {
   return expr_->match(e);

--- a/src/lib/test/match.cpp
+++ b/src/lib/test/match.cpp
@@ -203,3 +203,23 @@ TEST_CASE("all of matching") {
     REQUIRE(ex.match(c));
   }
 }
+
+TEST_CASE("tail matching") {
+  auto ex = AllOf{
+    Child(0, Exact(Symbol("store"))),
+    Tail(IsComposite())
+  };
+
+  auto c = Composite{
+    Symbol("store"),
+    Composite(),
+    Composite{Symbol("feij")}
+  };
+  REQUIRE(ex.match(c));
+
+  auto d = Composite{
+    Composite(),
+    Composite{Symbol("feij")}
+  };
+  REQUIRE(!ex.match(d));
+}


### PR DESCRIPTION
This makes an easy way of checking variable-length expressions.