### PR TITLE
Fix leaks

### DIFF
--- a/src/lib/include/ast/match.h
+++ b/src/lib/include/ast/match.h
@@ -15,6 +15,8 @@ public:
   virtual bool match(const Expression &e) const = 0;
 
   virtual MatchExpression* clone() const = 0;
+
+  virtual ~MatchExpression() {}
 };
 
 /**
@@ -101,7 +103,7 @@ AnyOf::AnyOf(T&& t, Ts&&... rest) :
 
 class AllOf : public MatchExpression {
 public:
-  AllOf() = default;
+  AllOf() {}
 
   template<class T, class... Ts>
   AllOf(T&& t, Ts&&... rest);

--- a/src/lib/include/ast/match.h
+++ b/src/lib/include/ast/match.h
@@ -96,7 +96,7 @@ template<class T, class... Ts>
 AnyOf::AnyOf(T&& t, Ts&&... rest) :
   AnyOf(rest...)
 {
-  exprs_.emplace_back(std::move(t).clone());
+  exprs_.emplace_back(t.clone());
 }
 
 class AllOf : public MatchExpression {
@@ -116,7 +116,7 @@ template<class T, class... Ts>
 AllOf::AllOf(T&& t, Ts&&... rest) :
   AllOf(rest...)
 {
-  exprs_.emplace_back(std::move(t).clone());
+  exprs_.emplace_back(t.clone());
 }
 
 /**


### PR DESCRIPTION
Memory was being leaked because `MatchExpression` didn't have a virtual destructor - after fixing this, the test suite runs with no memory leaks.