### PR TITLE
Recursive matching

### DIFF
--- a/src/lib/include/ast/match.h
+++ b/src/lib/include/ast/match.h
@@ -3,6 +3,7 @@
 
 #include <ast/ast.h>
 
+#include <functional>
 #include <vector>
 
 namespace ast {
@@ -204,6 +205,18 @@ public:
 private:
   std::unique_ptr<MatchExpression> expr_;
 };
+
+class Recursive : public MatchExpression {
+public:
+  Recursive(std::function<Matcher()> f) :
+    func_(f) {}
+
+  virtual bool match(const Expression &e) const override;
+  virtual Recursive* clone() const override { return new Recursive(func_); }
+private:
+  std::function<Matcher()> func_;
+};
+
 
 struct MatchResult {
   MatchResult(const Expression& e) :

--- a/src/lib/src/match.cpp
+++ b/src/lib/src/match.cpp
@@ -120,6 +120,11 @@ bool Tail::match(const Expression &e) const
   return false;
 }
 
+bool Recursive::match(const Expression &e) const
+{
+  return func_().match(e);
+}
+
 bool Matcher::match(const Expression &e) const
 {
   return expr_->match(e);

--- a/src/lib/test/match.cpp
+++ b/src/lib/test/match.cpp
@@ -242,8 +242,9 @@ TEST_CASE("recursive matching") {
     auto ex = Recursive(r);
 
     REQUIRE(ex.match(Symbol("a")));
+    REQUIRE(!ex.match(Symbol("b")));
     
-    REQUIRE(ex.match(Composite{Symbol("a")}));
+    REQUIRE(ex.match(Composite{Symbol("a"), Symbol("b")}));
     REQUIRE(ex.match(Composite{Composite{Symbol("a")}}));
     REQUIRE(ex.match(Composite{Composite{Composite{Symbol("a")}}}));
   }

--- a/src/lib/test/match.cpp
+++ b/src/lib/test/match.cpp
@@ -223,3 +223,28 @@ TEST_CASE("tail matching") {
   };
   REQUIRE(!ex.match(d));
 }
+
+TEST_CASE("recursive matching") {
+  SECTION("basic delaying") {
+    auto d = [] { return Exact(Symbol("a")); };
+    auto ex = Recursive(d);
+
+    REQUIRE(ex.match(Symbol("a")));
+  }
+
+  SECTION("recursive") {
+    std::function<Matcher()> r = [&] {
+      return AnyOf{
+        Child(0, Recursive(r)),
+        Exact(Symbol("a"))
+      };
+    };
+    auto ex = Recursive(r);
+
+    REQUIRE(ex.match(Symbol("a")));
+    
+    REQUIRE(ex.match(Composite{Symbol("a")}));
+    REQUIRE(ex.match(Composite{Composite{Symbol("a")}}));
+    REQUIRE(ex.match(Composite{Composite{Composite{Symbol("a")}}}));
+  }
+}


### PR DESCRIPTION
This allows for self-referential matchers to be defined (by using a function to delay the evaluation of a recursive call).