### PR TITLE
Implement explicit casting functions

### DIFF
--- a/src/lib/include/ast/ast.h
+++ b/src/lib/include/ast/ast.h
@@ -8,11 +8,17 @@
 
 namespace ast {
 
+class Symbol;
+class Composite;
+
 class Expression {
 public:
   virtual std::string str() const = 0;
 
   virtual Expression *clone() const = 0;
+
+  virtual Symbol* symbol() = 0;
+  virtual Composite* composite() = 0;
 
   virtual ~Expression() {}
 };
@@ -26,6 +32,9 @@ public:
   std::string str() const override;
 
   Symbol *clone() const override;
+
+  virtual Symbol* symbol() override { return this; }
+  virtual Composite* composite() override { return nullptr; }
 };
 
 class Composite : public Expression {
@@ -53,6 +62,9 @@ public:
   std::string str() const override;
 
   Composite *clone() const override;
+
+  virtual Symbol* symbol() override { return nullptr; }
+  virtual Composite* composite() override { return this; }
 
   const std::unique_ptr<Expression>& operator [](std::size_t idx) const;
 private:

--- a/src/lib/test/ast.cpp
+++ b/src/lib/test/ast.cpp
@@ -145,3 +145,25 @@ TEST_CASE("composites can be cloned") {
   REQUIRE(clone != c);
   REQUIRE(*c == *clone);
 }
+
+TEST_CASE("expressions can be cast") {
+  SECTION("symbols") {
+    std::unique_ptr<ast::Expression> s = std::make_unique<ast::Symbol>("a");
+
+    auto s2 = s->symbol();
+    REQUIRE(s2);
+
+    auto c = s->composite();
+    REQUIRE(!c);
+  }
+
+  SECTION("composites") {
+    std::unique_ptr<ast::Expression> c = std::make_unique<ast::Composite>();
+
+    auto c2 = c->composite();
+    REQUIRE(c2);
+
+    auto s = c->symbol();
+    REQUIRE(!s);
+  }
+}


### PR DESCRIPTION
This just means less messing around with dynamic_cast et. al. - it's just a simple hand-rolled form of RTTI.